### PR TITLE
filter metric by cluster

### DIFF
--- a/src/apis/metric.ts
+++ b/src/apis/metric.ts
@@ -6,7 +6,7 @@ export const MetricApi = {
   querymetric(params) {
     return axios.get(`${url}/query`, { params });
   },
-  queryRangeMetric(params) {
-    return axios.get(`${url}/query_range`, { params });
+  queryRangeMetric(id, params) {
+    return axios.get(`${url}/query_range/${id}`, { params });
   },
 };

--- a/src/components/overview-base/chartOption.ts
+++ b/src/components/overview-base/chartOption.ts
@@ -71,7 +71,7 @@ export const chartOption = (data: MetricData[], min: number, max: number) => ({
         return `job:${metric.job}-task:${metric.task}`;
       }
     })(),
-    data: values.map(item => ([item[0] * 1000, item[1]])),
+    data: values.map(item => ([item[0] * 1000, Number(item[1]).toFixed(2).replace('.00', '')])),
     type: 'line',
     // sampling: 'average',
     symbol: 'none',

--- a/src/components/overview-base/overview-base.vue
+++ b/src/components/overview-base/overview-base.vue
@@ -70,16 +70,17 @@ export default {
     fetchData() {
       this.chartMetrics.forEach((item, index) => {
         item.metrics.forEach((metric, index) => {
-          this.fetchChartData(metric, index);
+          this.fetchChartData(item.title, metric, index);
         });
       });
     },
-    async fetchChartData(chart, index) {
+    async fetchChartData(title, chart, index) {
       const { duration, min, max } = convertTimeBounds(this.timeFilter);
       const step = Math.floor(+duration / 360 / 1000);
       const {
         data: { entity },
-      } = await MetricApi.queryRangeMetric({
+      } = await MetricApi.queryRangeMetric(this.$route.params.id, {
+        title: title,
         metric: chart.metric,
         start: Math.floor(min / 1000),
         end: Math.floor(max / 1000),

--- a/src/constants/Metrics.ts
+++ b/src/constants/Metrics.ts
@@ -3,40 +3,40 @@ export const Metrics = Object.freeze([
     title: 'ClickHouse Table KPIs',
     metrics: [{
       expect: 'clickhouse Query',
-      metric: 'ClickHouseMetrics_Query',
+      metric: 'ClickHouseMetrics_Query{instance=~"{{.hosts}}"}',
     }],
   },{
     title: 'ClickHouse Node KPIs',
     metrics: [{
       expect: 'cpu usage',
-      metric: '100 * (1 - sum(increase(node_cpu_seconds_total{mode="idle"}[1m])) by (instance) / sum(increase(node_cpu_seconds_total[1m])) by (instance))',
+      metric: '100 * (1 - sum(increase(node_cpu_seconds_total{mode="idle",instance=~"{{.hosts}}"}[1m])) by (instance) / sum(increase(node_cpu_seconds_total{instance=~"{{.hosts}}"}[1m])) by (instance))',
     },{
       expect: 'memory usage',
-      metric: '100 * (1 - (node_memory_MemFree_bytes+node_memory_Buffers_bytes+node_memory_Cached_bytes)/node_memory_MemTotal_bytes)',
+      metric: '100 * (1 - (node_memory_MemFree_bytes{instance=~"{{.hosts}}"}+node_memory_Buffers_bytes{instance=~"{{.hosts}}"}+node_memory_Cached_bytes{instance=~"{{.hosts}}"})/node_memory_MemTotal_bytes{instance=~"{{.hosts}}"})',
     },{
       expect: 'disk usage',
-      metric: "100 * (1 - node_filesystem_avail_bytes{fstype !~'tmpfs'} / node_filesystem_size_bytes{fstype !~'tmpfs'})",
+      metric: '100 * (1 - node_filesystem_avail_bytes{fstype !~"tmpfs",instance=~"{{.hosts}}"} / node_filesystem_size_bytes{fstype !~"tmpfs",instance=~"{{.hosts}}"})',
     },{
       expect: 'IOPS',
-      metric: 'irate(node_disk_writes_completed_total[1m])+irate(node_disk_reads_completed_total[1m])',
+      metric: 'irate(node_disk_writes_completed_total{instance=~"{{.hosts}}"}[1m])+irate(node_disk_reads_completed_total{instance=~"{{.hosts}}"}[1m])',
     }],
   },{
     title: 'ZooKeeper KPIs',
     metrics: [{
       expect: 'znode_count',
-      metric: 'znode_count',
+      metric: 'znode_count{instance=~"{{.hosts}}"}',
     },{
       expect: 'leader_uptime',
-      metric: 'increase(leader_uptime[1m])',
+      metric: 'increase(leader_uptime{instance=~"{{.hosts}}"}[1m])',
     },{
       expect: 'stale_sessions_expired',
-      metric: 'stale_sessions_expired',
+      metric: 'stale_sessions_expired{instance=~"{{.hosts}}"}',
     },{
       expect: 'jvm_gc_collection_seconds_count',
-      metric: 'jvm_gc_collection_seconds_count',
+      metric: 'jvm_gc_collection_seconds_count{instance=~"{{.hosts}}"}',
     },{
       expect: 'jvm_gc_collection_seconds_sum',
-      metric: 'jvm_gc_collection_seconds_sum',
+      metric: 'jvm_gc_collection_seconds_sum{instance=~"{{.hosts}}"}',
     }],
   },
 ]);


### PR DESCRIPTION
修复两个问题：
- overview页面小数点太多，默认保留小数点后两位
- 更新QueryRange API，按照cluster名称过滤