### PR TITLE
优化：在表指标页面的表行数加入千分位，提升可读性

### DIFF
--- a/src/views/tables/components/tableMetrics.vue
+++ b/src/views/tables/components/tableMetrics.vue
@@ -240,6 +240,7 @@ export default {
         values.readwrite_status = values.readwrite_status.toString().toUpperCase();
         values.queryCost = Object.values(values.queryCost).join(',');
         values.tableName = key;
+        values.rows = values.rows.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","); // 加入数字千分位分隔符
         return values;
       }));
       this.pagination.total = this.tableData.length;


### PR DESCRIPTION
在表管理-表指标页面，大表行数的位数很长，通常9位以上，为了方便和快速阅读表的行数，增加了表行数千分位标记。
例如，999888777，优化为999,888,777。
（参考DBeaver ui工具的查询结构默认是加了千分位）